### PR TITLE
Acknowledge Incident In PagerDuty

### DIFF
--- a/github-workflows/pagerduty/README.md
+++ b/github-workflows/pagerduty/README.md
@@ -587,8 +587,7 @@ on:
 jobs:
   change-incident-owner:
     runs-on: ubuntu-latest
-    steps:
-      
+    steps:      
       - name: Inform execution of request to change incident owner
         uses: port-labs/port-github-action@v1
         with:
@@ -742,7 +741,6 @@ jobs:
   acknowledge_incident:
     runs-on: ubuntu-latest
     steps:
-      
       - name: Log Executing Request to Acknowledge Incident
         uses: port-labs/port-github-action@v1
         with:

--- a/github-workflows/pagerduty/README.md
+++ b/github-workflows/pagerduty/README.md
@@ -769,6 +769,17 @@ jobs:
                 ]
               }
 
+      - name: Log Acknowledge Incident Request Failure 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Request to acknowledge incident failed ..."
+
       - name: Log Before Processing Incident Response
         uses: port-labs/port-github-action@v1
         with:
@@ -810,6 +821,17 @@ jobs:
           baseUrl: https://api.getport.io
           operation: UPSERT
           runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Log Upsert Entity Failure 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Failed to upsert pagerduty incident to port ..."
 
       - name: Log After Upserting Entity
         uses: port-labs/port-github-action@v1

--- a/github-workflows/pagerduty/README.md
+++ b/github-workflows/pagerduty/README.md
@@ -478,3 +478,351 @@ jobs:
 6. Trigger the action from Port's [Self Serve](https://app.getport.io/self-serve)
 
 Congrats 🎉 You've created your first incident in PagerDuty from Port!
+
+
+# Change Incident Owner In Pagerduty
+
+This GitHub action allows you to quickly change incident owner in PagerDuty via Port Actions with ease.
+
+## Inputs
+| Name                 | Description                                                                                          | Required | Default            |
+|----------------------|------------------------------------------------------------------------------------------------------|----------|--------------------|
+| incident_id         | ID of the PagerDuty Incident     | true    | -                  |
+| new_owner_user_id              | PagerDuty User ID of the new owner                                | true     | -                  |
+| from              | The email address of a valid user associated with the account making the request.                                                              | true    | -               |
+
+## Quickstart - Change Incident Owner In Pagerduty
+
+1. Create the following GitHub action secrets
+* `PAGERDUTY_API_KEY` - PagerDuty API Key [learn more](https://support.pagerduty.com/docs/
+* `PORT_CLIENT_ID` - Port Client ID [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token)
+* `PORT_CLIENT_SECRET` - Port Client Secret [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token) 
+
+2. Install the Ports GitHub app from [here](https://github.com/apps/getport-io/installations/new).
+3. Install Port's pager duty integration [learn more](https://github.com/port-labs/Port-Ocean/tree/main/integrations/pagerduty)
+>**Note** This step is not required for this example, but it will create all the blueprint boilerplate for you, and also update the catalog in real time with the new incident created.
+4. After you installed the integration, the blueprints `pagerdutyService` and `pagerdutyIncident` will appear, create the following action with the following JSON file on the `pagerdutyIncident` blueprint:
+
+```json
+
+{
+  "identifier": "change_incident_owner",
+  "title": "Change Incident Owner",
+  "icon": "pagerduty",
+  "userInputs": {
+    "properties": {
+      "incident_id": {
+        "icon": "pagerduty",
+        "title": "Incident Id",
+        "description": "ID of the PagerDuty Incident",
+        "type": "string",
+        "blueprint": "pagerdutyIncident",
+        "format": "entity"
+      },
+      "new_owner_user_id": {
+        "title": "New Owner User ID",
+        "description": "PagerDuty User ID of the new owner",
+        "icon": "pagerduty",
+        "type": "string"
+      },
+      "from": {
+        "icon": "pagerduty",
+        "title": "From",
+        "description": "The email address of a valid user associated with the account making the request.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "new_owner_user_id",
+      "incident_id",
+      "from"
+    ],
+    "order": [
+      "incident_id",
+      "new_owner_user_id",
+      "from"
+    ]
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "your-github-organization",
+    "repo": "your-github-repo",
+    "workflow": "change-incident-owner.yaml",
+    "omitUserInputs": false,
+    "omitPayload": false,
+    "reportWorkflowStatus": true
+  },
+  "trigger": "DAY-2",
+  "description": "Change Incident Owner in pagerduty",
+  "requiredApproval": false
+}
+```
+>**Note** Replace the invocation method with your own repository details.
+
+5. Create a workflow file under .github/workflows/change-incident-owner.yaml with the following content:
+
+```yml
+name: Change PagerDuty Incident Owner
+
+on:
+  workflow_dispatch:
+    inputs:
+      incident_id:
+        description: ID of the PagerDuty Incident
+        required: true
+        type: string
+      new_owner_user_id:
+        description: PagerDuty User ID of the new owner
+        required: true
+        type: string
+      from:
+        description: The email address of a valid user associated with the account making the request.
+        required: true
+        type: string
+      port_payload:
+        required: true
+        description: >-
+          Port's payload, including details for who triggered the action and
+          general context (blueprint, run id, etc...)
+
+jobs:
+  change-incident-owner:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Inform execution of request to change incident owner
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "About to make a request to pagerduty..."
+
+      - name: Change Incident Owner in PagerDuty
+        id: change_owner
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.pagerduty.com/incidents/${{ github.event.inputs.incident_id }}'
+          method: 'PUT'
+          customHeaders: '{"Content-Type": "application/json", "Accept": "application/vnd.pagerduty+json;version=2", "Authorization": "Token token=${{ secrets.PAGERDUTY_API_KEY }}", "From": "${{ github.event.inputs.from }}"}'
+          data: >-
+            {
+              "incident": {
+                "type": "incident_reference",
+                "assignments": [
+                  {
+                    "assignee": {
+                      "id": "${{ github.event.inputs.new_owner_user_id }}",
+                      "type": "user_reference"
+                    }
+                  }
+                ]
+              }
+            }
+
+      - name: Inform ingestion of pagerduty feature flag to Port
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Reporting the updated incident back to port ..."
+
+      - name: Upsert pagerduty entity to Port 
+        uses: port-labs/port-github-action@v1
+        with:
+          identifier: "${{ fromJson(steps.change_owner.outputs.response).incident.id }}"
+          title: "${{ fromJson(steps.change_owner.outputs.response).incident.title }}"
+          blueprint: "pagerdutyIncident"
+          properties: |-
+            {
+              "status": "${{ fromJson(steps.change_owner.outputs.response).incident.status }}",
+              "url": "${{ fromJson(steps.change_owner.outputs.response).incident.self }}",
+              "urgency": "${{ fromJson(steps.change_owner.outputs.response).incident.urgency }}",
+              "responder": "${{ fromJson(steps.change_owner.outputs.response).incident.assignments[0].assignee.summary}}",
+              "escalation_policy": "${{ fromJson(steps.change_owner.outputs.response).incident.escalation_policy.summary }}",
+              "created_at": "${{ fromJson(steps.change_owner.outputs.response).incident.created_at }}",
+              "updated_at": "${{ fromJson(steps.change_owner.outputs.response).incident.updated_at }}"
+            }
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Inform completion of pagerduty feature flag ingestion into Port
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Entity upserting was successful ✅"
+```
+
+
+# Acknowledge Incident In Pagerduty
+
+This GitHub action allows you to quickly acknowledge incident in PagerDuty via Port Actions with ease.
+
+## Inputs
+| Name                 | Description                                                                                          | Required | Default            |
+|----------------------|------------------------------------------------------------------------------------------------------|----------|--------------------
+| from              | The email address of a valid user associated with the account making the request.                                                              | true    | -               |
+
+## Quickstart - Acknowledge Incident In Pagerduty
+
+1. Create the following GitHub action secrets
+* `PAGERDUTY_API_KEY` - PagerDuty API Key [learn more](https://support.pagerduty.com/docs/
+* `PORT_CLIENT_ID` - Port Client ID [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token)
+* `PORT_CLIENT_SECRET` - Port Client Secret [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token) 
+
+2. Install the Ports GitHub app from [here](https://github.com/apps/getport-io/installations/new).
+3. Install Port's pager duty integration [learn more](https://github.com/port-labs/Port-Ocean/tree/main/integrations/pagerduty)
+>**Note** This step is not required for this example, but it will create all the blueprint boilerplate for you, and also update the catalog in real time with the new incident created.
+4. After you installed the integration, the blueprints `pagerdutyService` and `pagerdutyIncident` will appear, create the following action with the following JSON file on the `pagerdutyIncident` blueprint:
+
+```json
+{
+  "identifier": "acknowledge_incident",
+  "title": "Acknowledge Incident",
+  "icon": "pagerduty",
+  "userInputs": {
+    "properties": {
+      "from": {
+        "icon": "pagerduty",
+        "title": "From",
+        "description": "User Email",
+        "type": "string"
+      }
+    },
+    "required": [],
+    "order": [
+      "from"
+    ]
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "mk-armah",
+    "repo": "jira-actions",
+    "workflow": "acknowledge-incidents.yaml",
+    "omitUserInputs": false,
+    "omitPayload": false,
+    "reportWorkflowStatus": true
+  },
+  "trigger": "DAY-2",
+  "description": "Acknowledge incident in pagerduty",
+  "requiredApproval": false
+}
+```
+>**Note** Replace the invocation method with your own repository details.
+
+5. Create a workflow file under .github/workflows/acknowledge-incident.yaml with the following content:
+
+```yml
+name: Acknowledge Incident In PagerDuty
+on:
+  workflow_dispatch:
+    inputs:
+      from:
+        description: The email address of a valid user associated with the account making the request.
+        required: true
+        type: string
+      port_payload:
+        required: true
+        description: >-
+          Port's payload, including details for who triggered the action and
+          general context (blueprint, run id, etc...)
+
+jobs:
+  acknowledge_incident:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Log Executing Request to Acknowledge Incident
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "About to make a request to pagerduty..."
+
+      - name: Request to Acknowledge Incident
+        id: acknowledge_incident
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.pagerduty.com/incidents'
+          method: 'PUT'
+          customHeaders: '{"Content-Type": "application/json", "Accept": "application/vnd.pagerduty+json;version=2", "Authorization": "Token token=${{ secrets.PAGERDUTY_API_KEY }}", "From": "${{ github.event.inputs.from }}"}'
+          data: >-
+              {
+                "incidents": [
+                  {
+                    "id": "${{ fromJson(inputs.port_payload).context.entity }}",
+                    "type": "incident_reference",
+                    "status": "acknowledged"
+                  }
+                ]
+              }
+
+      - name: Log Before Processing Incident Response
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Getting incident object from response received ..."
+
+      - name: Log Before Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Reporting the updated incident back to port ..."
+
+      - name: UPSERT Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          identifier: "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].id }}"
+          title: "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].title }}"
+          blueprint: ${{ fromJson(inputs.port_payload).context.blueprint }}
+          properties: |-
+            {
+              "status": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].status }}",
+              "url": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].self }}",
+              "urgency": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].urgency }}",
+              "responder": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].assignments[0].assignee.summary}}",
+              "escalation_policy": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].escalation_policy.summary }}",
+              "created_at": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].created_at }}",
+              "updated_at": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].updated_at }}"
+            }
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Log After Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Entity upserting was successful ✅"
+```
+
+Congrats 🎉 You've successfully acknowledged an incident in PagerDuty from Port!

--- a/github-workflows/pagerduty/acknowledge-incident.yaml
+++ b/github-workflows/pagerduty/acknowledge-incident.yaml
@@ -16,7 +16,6 @@ jobs:
   acknowledge_incident:
     runs-on: ubuntu-latest
     steps:
-      
       - name: Log Executing Request to Acknowledge Incident
         uses: port-labs/port-github-action@v1
         with:
@@ -44,6 +43,17 @@ jobs:
                   }
                 ]
               }
+
+      - name: Log Acknowledge Incident Request Failure 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Request to acknowledge incident failed ..."
 
       - name: Log Before Processing Incident Response
         uses: port-labs/port-github-action@v1
@@ -86,6 +96,17 @@ jobs:
           baseUrl: https://api.getport.io
           operation: UPSERT
           runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Log Upsert Entity Failure 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Failed to upsert pagerduty incident to port ..."
 
       - name: Log After Upserting Entity
         uses: port-labs/port-github-action@v1

--- a/github-workflows/pagerduty/acknowledge-incident.yaml
+++ b/github-workflows/pagerduty/acknowledge-incident.yaml
@@ -1,0 +1,98 @@
+name: Acknowledge Incident In PagerDuty
+on:
+  workflow_dispatch:
+    inputs:
+      from:
+        description: The email address of a valid user associated with the account making the request.
+        required: true
+        type: string
+      port_payload:
+        required: true
+        description: >-
+          Port's payload, including details for who triggered the action and
+          general context (blueprint, run id, etc...)
+
+jobs:
+  acknowledge_incident:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Log Executing Request to Acknowledge Incident
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "About to make a request to pagerduty..."
+
+      - name: Request to Acknowledge Incident
+        id: acknowledge_incident
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.pagerduty.com/incidents'
+          method: 'PUT'
+          customHeaders: '{"Content-Type": "application/json", "Accept": "application/vnd.pagerduty+json;version=2", "Authorization": "Token token=${{ secrets.PAGERDUTY_API_KEY }}", "From": "${{ github.event.inputs.from }}"}'
+          data: >-
+              {
+                "incidents": [
+                  {
+                    "id": "${{ fromJson(inputs.port_payload).context.entity }}",
+                    "type": "incident_reference",
+                    "status": "acknowledged"
+                  }
+                ]
+              }
+
+      - name: Log Before Processing Incident Response
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Getting incident object from response received ..."
+
+      - name: Log Before Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Reporting the updated incident back to port ..."
+
+      - name: UPSERT Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          identifier: "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].id }}"
+          title: "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].title }}"
+          blueprint: ${{ fromJson(inputs.port_payload).context.blueprint }}
+          properties: |-
+            {
+              "status": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].status }}",
+              "url": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].self }}",
+              "urgency": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].urgency }}",
+              "responder": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].assignments[0].assignee.summary}}",
+              "escalation_policy": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].escalation_policy.summary }}",
+              "created_at": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].created_at }}",
+              "updated_at": "${{ fromJson(steps.acknowledge_incident.outputs.response).incidents[0].updated_at }}"
+            }
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Log After Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Entity upserting was successful ✅"


### PR DESCRIPTION
Added github action to enable acknowlegment of pagerduty incident from port
This action takes `from` as input parameter and leverages incident details present in port to update pagerduty incident status to acknowleged

## Inputs
| Name                 | Description                                                                                          | Required | Default            |
|----------------------|------------------------------------------------------------------------------------------------------|----------|--------------------
| from              | The email address of a valid user associated with the account making the request.                                                              | true    | -               |
